### PR TITLE
Original Legal Entity Id Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 CHANGELOG
 ---------
+## 13.0.1
+* **BugFix** original Legal Entity camel casing is corrected
 
 ## 13.0.0
 * **Feature** Support for PayFac MP API version 13.0

--- a/src/main/xsd/merchant-onboard-api-v13.xsd
+++ b/src/main/xsd/merchant-onboard-api-v13.xsd
@@ -329,7 +329,7 @@
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:element>
-                    <xs:element name="originallegalEntityId"  minOccurs="0">
+                    <xs:element name="originalLegalEntityId"  minOccurs="0">
                         <xs:simpleType>
                             <xs:restriction base="xs:string">
                                 <xs:minLength value="1"/>
@@ -337,7 +337,7 @@
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:element>
-                    <xs:element name="originallegalEntityStatus"  minOccurs="0">
+                    <xs:element name="originalLegalEntityStatus"  minOccurs="0">
                         <xs:simpleType>
                             <xs:restriction base="xs:string">
                                 <xs:minLength value="1"/>

--- a/src/test/java/com/mp/sdk/functionalTest/TestPayFacLegalEntity.java
+++ b/src/test/java/com/mp/sdk/functionalTest/TestPayFacLegalEntity.java
@@ -23,6 +23,7 @@ import com.mp.sdk.LegalEntityType;
 import com.mp.sdk.LegalEntityUpdateRequest;
 import com.mp.sdk.PayFacLegalEntity;
 import com.mp.sdk.PrincipalAddress;
+import com.mp.sdk.XMLConverters;
 
 public class TestPayFacLegalEntity {
 
@@ -133,9 +134,12 @@ public class TestPayFacLegalEntity {
 
     @Test
     public void testPostByLegalEntity(){
+        //String rawXml = XMLConverters.generateLegalEntityCreateRequest(createRequest);
+        //System.out.println(rawXml);
         LegalEntityCreateResponse response = payFacLegalEntity.postByLegalEntity(createRequest);
         assertNotNull(response.getTransactionId());
         assertNotNull(response.getLegalEntityId());
+        System.out.println(response);
         assertEquals((short)10,(short)response.getResponseCode());
     }
 

--- a/src/test/java/com/mp/sdk/functionalTest/TestPayFacLegalEntity.java
+++ b/src/test/java/com/mp/sdk/functionalTest/TestPayFacLegalEntity.java
@@ -23,7 +23,6 @@ import com.mp.sdk.LegalEntityType;
 import com.mp.sdk.LegalEntityUpdateRequest;
 import com.mp.sdk.PayFacLegalEntity;
 import com.mp.sdk.PrincipalAddress;
-import com.mp.sdk.XMLConverters;
 
 public class TestPayFacLegalEntity {
 
@@ -137,7 +136,6 @@ public class TestPayFacLegalEntity {
         LegalEntityCreateResponse response = payFacLegalEntity.postByLegalEntity(createRequest);
         assertNotNull(response.getTransactionId());
         assertNotNull(response.getLegalEntityId());
-        System.out.println(response);
         assertEquals((short)10,(short)response.getResponseCode());
     }
 

--- a/src/test/java/com/mp/sdk/functionalTest/TestPayFacLegalEntity.java
+++ b/src/test/java/com/mp/sdk/functionalTest/TestPayFacLegalEntity.java
@@ -134,8 +134,6 @@ public class TestPayFacLegalEntity {
 
     @Test
     public void testPostByLegalEntity(){
-        //String rawXml = XMLConverters.generateLegalEntityCreateRequest(createRequest);
-        //System.out.println(rawXml);
         LegalEntityCreateResponse response = payFacLegalEntity.postByLegalEntity(createRequest);
         assertNotNull(response.getTransactionId());
         assertNotNull(response.getLegalEntityId());


### PR DESCRIPTION
The goal of this change is to fix a bug in camelcasing that was causing originalLegalEntityId to not be deserialized correctly